### PR TITLE
output a single FeatureCollection (and trap auth errors)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 sudo: false
 language: node_js
+node_js:
+  - "6"

--- a/test.js
+++ b/test.js
@@ -19,7 +19,7 @@ test('nj', function (t) {
         t.deepEqual(result.features[0].properties.name, 'New Jersey');
         t.deepEqual(result.features[0].geometry, {
             type: 'Point',
-            coordinates: [-74.38928604125977, 40.150275473401365]
+            coordinates: [-74.38928604125977, 40.15027547340139]
         });
         t.end();
     });


### PR DESCRIPTION
resolves #2 
- group output features in a single `FeatureCollection`
- return a more informative error when an invalid token is provided.

what's thrown currently for `access_token=foo` is pretty cryptic.

``` bash
/Users/john6251/github/vt2geojson/node_modules/pbf/index.js:195
        else throw new Error('Unimplemented type: ' + type);
             ^

Error: Unimplemented type: 3
```
- switch to single quotes and tweak output geometry by 1/1,000,000th of a gnat's eyelash to get tests passing in Node 6.
