### PR TITLE
Tests for multiple layer properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function(args, callback) {
             args.y = zxy[3];
         }
     }
-    
+
     var parsed = url.parse(args.uri);
     if (parsed.protocol && (parsed.protocol === 'http:' || parsed.protocol === 'https:')) {
         request.get({
@@ -32,7 +32,7 @@ module.exports = function(args, callback) {
             encoding: null
         }, function (err, response, body) {
             if (err) throw err;
-            if (response.statusCode === 401 && response.statusMessage === 'Unauthorized') {
+            if (response.statusCode === 401) {
                 return callback(new Error('Invalid Token'));
             }
             if (response.statusCode !== 200) {
@@ -79,9 +79,9 @@ function readTile(args, buffer, callback) {
             for (var i = 0; i < layer.length; i++) {
                 var feature = layer.feature(i).toGeoJSON(args.x, args.y, args.z);
                 feature.coordinates = layer.feature(i).loadGeometry();
-                if (layers.length > 1) feature.properties.layer = layerID;
+                if (layers.length > 1) feature.properties.vt_layer = layerID;
                 collection.features.push(feature);
-            } 
+            }
         }
     });
 

--- a/test.js
+++ b/test.js
@@ -13,6 +13,14 @@ var tile2 = nock('http://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7')
     .get('/16/46886/30383.mvt')
     .reply(200, fs.readFileSync('fixtures/16-46886-30383.mvt'));
 
+var invalidTokenRequest = nock('http://invalid.mapbox.com')
+    .get('/16/46886/30383.mvt')
+    .reply(401);
+
+var fourohfour = nock('http://404.mapbox.com')
+    .get('/16/46886/0.mvt')
+    .reply(404);
+
 test('fails without uri', function (t) {
     vt2geojson({}, function (err, result) {
        t.ok(err);
@@ -20,7 +28,7 @@ test('fails without uri', function (t) {
        t.notOk(result);
        t.end();
     });
-})
+});
 
 test('fails without zxy', function (t) {
     vt2geojson({
@@ -32,6 +40,28 @@ test('fails without zxy', function (t) {
        t.notOk(result);
        t.end();
     });
+});
+
+test('fails with 401 response: invalid token', function (t) {
+  vt2geojson({
+      uri: 'http://invalid.mapbox.com/16/46886/30383.mvt',
+      layer: 'state_label'
+  }, function (err, result) {
+      t.ok(err);
+      t.ok(/Invalid Token/.test(err.message), 'expected error message');
+      t.end();
+  });
+});
+
+test('fails 404 response', function (t) {
+  vt2geojson({
+      uri: 'http://404.mapbox.com/16/46886/0.mvt',
+      layer: 'state_label'
+  }, function (err, result) {
+      t.ok(err);
+      t.ok(/Error retrieving data from/.test(err.message), 'expected error message');
+      t.end();
+  });
 });
 
 test('url', function (t) {
@@ -131,6 +161,24 @@ test('local file gzipped', function (t) {
         t.deepEqual(result.features[0].geometry, {
             type: 'Point',
             coordinates: [-74.38928604125977, 40.15027547340139]
+        });
+        t.end();
+    });
+});
+
+test('multiple layers adds property to preserve layer name', function (t) {
+    vt2geojson({
+        uri: './fixtures/16-46886-30383.mvt',
+        z: 16,
+        x: 46886,
+        y: 30383,
+        layer: ['landuse', 'poi_label']
+    }, function (err, result) {
+        t.equal(result.type, 'FeatureCollection', 'expected type');
+        t.equal(result.features.length, 112, 'expected number of features');
+        result.features.forEach(function(f) {
+          var val = (f.properties.vt_layer === 'landuse' || f.properties.vt_layer === 'poi_label') ? true : false;
+          t.ok(val, 'expected property value');
         });
         t.end();
     });


### PR DESCRIPTION
Adding tests for #6 and renaming newly created property to `vt_layer`.

Also adding tests for `401` and `404` responses.

cc @amishas157 