### PR TITLE
Expose buffer-geojson conversion method

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,3 +88,5 @@ function readTile(args, buffer, callback) {
 
     callback(null, collection);
 }
+
+module.exports.fromBuffer = readTile


### PR DESCRIPTION
Simply expose the function `readTile` as `fromBuffer` in the exports. This allows one to use this library in situations in which the tile has already been loaded but needs to be converted. In my case, I was writing tests for a tileserver with `supertest` and wanted to validate that all expected layers were returned in the protocol buffer. 