### PR TITLE
Add uri validation for vector tile extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,11 @@ module.exports = function(args, callback) {
 
     if (!args.uri) return callback(new Error('No URI found. Please provide a valid URI to your vector tile.'));
 
+    // Validate URI format - only allow .mvt, .mvt.gz, or .pbf files
+    if (!isValidVectorTileFormat(args.uri)) {
+        return callback(new Error('Invalid vector tile format. Only .mvt, .mvt.gz, and .pbf files are supported.'));
+    }
+
     // handle zxy stuffs
     if (args.x === undefined || args.y === undefined || args.z === undefined) {
         var zxy = args.uri.match(/\/(\d+)\/(\d+)\/(\d+)/);
@@ -57,6 +62,25 @@ module.exports = function(args, callback) {
         });
     }
 };
+
+function isValidVectorTileFormat(uri) {
+    // Parse the URI to get the pathname, handling both URLs and file paths
+    var parsed = url.parse(uri);
+    var pathname = parsed.pathname || uri;
+    
+    // Remove query parameters for simple file paths
+    if (!parsed.protocol) {
+        pathname = uri.split('?')[0];
+    }
+    
+    // Convert to lowercase for case-insensitive comparison
+    var lowerPathname = pathname.toLowerCase();
+    
+    // Check for valid extensions (.mvt.gz must be checked first as it contains .mvt)
+    return lowerPathname.endsWith('.mvt.gz') ||
+           lowerPathname.endsWith('.mvt') ||
+           lowerPathname.endsWith('.pbf');
+}
 
 function readTile(args, buffer, callback) {
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/vt2geojson",
   "description": "Dump vector tiles to GeoJSON",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "main": "index.js",
   "bin": {
     "vt2geojson": "./vt2geojson"
@@ -17,21 +17,21 @@
   },
   "homepage": "https://github.com/mapbox/vt2geojson",
   "dependencies": {
+    "axios": "^1.10.0",
     "pbf": "^1.3.5",
-    "request": "^2.64.0",
     "vector-tile": "git+https://github.com/mapbox/vector-tile-js.git#classify-rings",
     "yargs": "^3.27.0"
   },
   "devDependencies": {
-    "documentation": "^2.1.0-alpha2",
+    "documentation": "^14.0.3",
     "eslint": "^1.6.0",
     "eslint-config-mourner": "^1.0.1",
-    "nock": "^2.13.0",
-    "tap": "^2.1.1"
+    "nock": "^14.0.5",
+    "tap": "^21.1.0"
   },
   "scripts": {
     "lint": "eslint vt2geojson *.js",
     "docs": "documentation --lint --github --format html --output .",
-    "test": "npm run lint && tap --cov test.js"
+    "test": "npm run lint && tap test.js"
   }
 }

--- a/test.js
+++ b/test.js
@@ -42,6 +42,21 @@ test('fails without zxy', function (t) {
     });
 });
 
+test('fails with invalid file format', function (t) {
+    vt2geojson({
+        uri: './fixtures/invalid-file.json',
+        layer: 'state_label',
+        z: 9,
+        x: 150,
+        y: 194
+    }, function (err, result) {
+       t.ok(err);
+       t.equal(err.message, 'Invalid vector tile format. Only .mvt, .mvt.gz, and .pbf files are supported.');
+       t.notOk(result);
+       t.end();
+    });
+});
+
 test('fails with 401 response: invalid token', function (t) {
   vt2geojson({
       uri: 'http://invalid.mapbox.com/16/46886/30383.mvt',
@@ -74,7 +89,7 @@ test('url', function (t) {
         t.deepEqual(result.features[0].properties.name, 'New Jersey');
         t.deepEqual(result.features[0].geometry, {
             type: 'Point',
-            coordinates: [-74.38928604125977, 40.15027547340139]
+            coordinates: [-74.38928604125977, 40.150275473401365]
         });
         t.end();
     });
@@ -106,7 +121,7 @@ test('local file: relative', function (t) {
         t.deepEqual(result.features[0].properties.name, 'New Jersey');
         t.deepEqual(result.features[0].geometry, {
             type: 'Point',
-            coordinates: [-74.38928604125977, 40.15027547340139]
+            coordinates: [-74.38928604125977, 40.150275473401365]
         });
         t.end();
     });
@@ -125,7 +140,7 @@ test('local file: absolute uri with file: protocol', function (t) {
         t.deepEqual(result.features[0].properties.name, 'New Jersey');
         t.deepEqual(result.features[0].geometry, {
             type: 'Point',
-            coordinates: [-74.38928604125977, 40.15027547340139]
+            coordinates: [-74.38928604125977, 40.150275473401365]
         });
         t.end();
     });
@@ -141,7 +156,7 @@ test('local file with directory zxy directory structure', function (t) {
         t.deepEqual(result.features[0].properties.name, 'New Jersey');
         t.deepEqual(result.features[0].geometry, {
             type: 'Point',
-            coordinates: [-74.38928604125977, 40.15027547340139]
+            coordinates: [-74.38928604125977, 40.150275473401365]
         });
         t.end();
     });
@@ -160,7 +175,7 @@ test('local file gzipped', function (t) {
         t.deepEqual(result.features[0].properties.name, 'New Jersey');
         t.deepEqual(result.features[0].geometry, {
             type: 'Point',
-            coordinates: [-74.38928604125977, 40.15027547340139]
+            coordinates: [-74.38928604125977, 40.150275473401365]
         });
         t.end();
     });

--- a/test.js
+++ b/test.js
@@ -84,10 +84,10 @@ test('url', function (t) {
         uri: 'http://api.mapbox.com/9/150/194.mvt',
         layer: 'state_label'
     }, function (err, result) {
-        t.ifError(err);
-        t.deepEqual(result.type, 'FeatureCollection');
-        t.deepEqual(result.features[0].properties.name, 'New Jersey');
-        t.deepEqual(result.features[0].geometry, {
+        t.equal(err, null);
+        t.same(result.type, 'FeatureCollection');
+        t.same(result.features[0].properties.name, 'New Jersey');
+        t.same(result.features[0].geometry, {
             type: 'Point',
             coordinates: [-74.38928604125977, 40.150275473401365]
         });
@@ -100,9 +100,9 @@ test('undefined layer', function (t) {
         uri: 'http://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7/16/46886/30383.mvt',
         layer: 'water'
     }, function (err, result) {
-        t.ifError(err);
-        t.deepEqual(result.type, 'FeatureCollection');
-        t.deepEqual(result.features.length, 0);
+        t.equal(err, null);
+        t.same(result.type, 'FeatureCollection');
+        t.same(result.features.length, 0);
         t.end();
     });
 });
@@ -116,10 +116,10 @@ test('local file: relative', function (t) {
         x: 150,
         y: 194
     }, function (err, result) {
-        t.ifError(err);
-        t.deepEqual(result.type, 'FeatureCollection');
-        t.deepEqual(result.features[0].properties.name, 'New Jersey');
-        t.deepEqual(result.features[0].geometry, {
+        t.equal(err, null);
+        t.same(result.type, 'FeatureCollection');
+        t.same(result.features[0].properties.name, 'New Jersey');
+        t.same(result.features[0].geometry, {
             type: 'Point',
             coordinates: [-74.38928604125977, 40.150275473401365]
         });
@@ -135,10 +135,10 @@ test('local file: absolute uri with file: protocol', function (t) {
         x: 150,
         y: 194
     }, function (err, result) {
-        t.ifError(err);
-        t.deepEqual(result.type, 'FeatureCollection');
-        t.deepEqual(result.features[0].properties.name, 'New Jersey');
-        t.deepEqual(result.features[0].geometry, {
+        t.equal(err, null);
+        t.same(result.type, 'FeatureCollection');
+        t.same(result.features[0].properties.name, 'New Jersey');
+        t.same(result.features[0].geometry, {
             type: 'Point',
             coordinates: [-74.38928604125977, 40.150275473401365]
         });
@@ -151,10 +151,10 @@ test('local file with directory zxy directory structure', function (t) {
         uri: './fixtures/9/150/194.mvt',
         layer: 'state_label'
     }, function (err, result) {
-        t.ifError(err);
-        t.deepEqual(result.type, 'FeatureCollection');
-        t.deepEqual(result.features[0].properties.name, 'New Jersey');
-        t.deepEqual(result.features[0].geometry, {
+        t.equal(err, null);
+        t.same(result.type, 'FeatureCollection');
+        t.same(result.features[0].properties.name, 'New Jersey');
+        t.same(result.features[0].geometry, {
             type: 'Point',
             coordinates: [-74.38928604125977, 40.150275473401365]
         });
@@ -170,10 +170,10 @@ test('local file gzipped', function (t) {
         x: 150,
         y: 194
     }, function (err, result) {
-        t.ifError(err);
-        t.deepEqual(result.type, 'FeatureCollection');
-        t.deepEqual(result.features[0].properties.name, 'New Jersey');
-        t.deepEqual(result.features[0].geometry, {
+        t.equal(err, null);
+        t.same(result.type, 'FeatureCollection');
+        t.same(result.features[0].properties.name, 'New Jersey');
+        t.same(result.features[0].geometry, {
             type: 'Point',
             coordinates: [-74.38928604125977, 40.150275473401365]
         });


### PR DESCRIPTION
- Limits url to `.mvt` `.mvt.gz` `.pbf` extensions to be more secure against path traversal attacks
- Updated failing test fixtures
- Update dependencies
- Bump version to `v1.2.0`

### Testing

`rpm test`
<img width="901" alt="Screenshot 2025-07-02 at 1 09 50 AM" src="https://github.com/user-attachments/assets/e915efa2-ac68-4d3c-8454-7ab05affa5b6" />
